### PR TITLE
removed deprecated rails function find_by_id rails v:4.1.8

### DIFF
--- a/lib/tenacity/orm_ext/activerecord.rb
+++ b/lib/tenacity/orm_ext/activerecord.rb
@@ -57,7 +57,7 @@ module Tenacity
         end
 
         def _t_find(id)
-          find_by_id(_t_serialize(id))
+          find(_t_serialize(id))
         end
 
         def _t_find_bulk(ids)


### PR DESCRIPTION
removed the deprecated function find_by_id
